### PR TITLE
#1: Allow shortcuts to work inside input fields with flag

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "chrome",
+            "request": "launch",
+            "name": "Launch Chrome against localhost",
+            "url": "http://localhost:9000",
+            "webRoot": "${workspaceFolder}"
+        }
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,14 @@
     "version": "0.2.0",
     "configurations": [
         {
+          "name": "Debug Jasmine tests",
+          "type": "chrome",
+          "request": "attach",
+          "port": 9222,
+          "sourceMaps": true,
+          "webRoot": "${workspaceRoot}"
+        },
+        {
             "type": "chrome",
             "request": "launch",
             "name": "Launch Chrome against localhost",

--- a/dev-app/app.html
+++ b/dev-app/app.html
@@ -1,3 +1,31 @@
 <template>
   <h1>${message}</h1>
+
+  <div>
+    <input placeholder="Input" />
+  </div>
+
+  <div>
+    <textarea placeholder="Text area"></textarea>
+  </div>
+
+  <div>
+    <select>
+      <option>Select</option>
+      <option>Dummy Option</option>
+      <option>Dummy Option</option>
+    </select>
+  </div>
+
+  <p>For this demo, the following keyboard shortcuts should work inside <code>input</code>s, <code>select</code>s and <code>textarea</code>s:</p>
+  <ul>
+    <li>ctrl+f</li>
+    <li>ctrl+c</li>
+  </ul>
+
+  <p>The following keyboard shortcuts will not work inside these elements:</p>
+  <ul>
+    <li>e</li>
+    <li>ctrl+x</li>
+  </ul>
 </template>

--- a/dev-app/app.js
+++ b/dev-app/app.js
@@ -15,4 +15,14 @@ export class App {
   copyIt() {
     console.log('copyIt');
   }
+
+  @combo('e')
+  editIt() {
+    console.log('editIt');
+  }
+
+  @combo('ctrl+x')
+  cutIt() {
+    console.log('cutIt');
+  }
 }

--- a/dev-app/app.js
+++ b/dev-app/app.js
@@ -6,7 +6,7 @@ export class App {
     this.message = 'Hello World!';
   }
 
-  @combo('ctrl+f', 'command+f')
+  @combo('ctrl+f, command+f')
   findIt() {
     console.log('findIt');
   }

--- a/dev-app/app.js
+++ b/dev-app/app.js
@@ -6,7 +6,7 @@ export class App {
     this.message = 'Hello World!';
   }
 
-  @combo('ctrl+f, command+f', true)
+  @combo('ctrl+f', 'command+f', true)
   findIt() {
     console.log('findIt');
   }

--- a/dev-app/app.js
+++ b/dev-app/app.js
@@ -6,12 +6,12 @@ export class App {
     this.message = 'Hello World!';
   }
 
-  @combo('ctrl+f, command+f')
+  @combo('ctrl+f, command+f', true)
   findIt() {
     console.log('findIt');
   }
 
-  @combo('ctrl+c, command+c')
+  @combo('ctrl+c, command+c', true)
   copyIt() {
     console.log('copyIt');
   }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -38,6 +38,11 @@ module.exports = function(config) {
       ChromeHeadlessNoSandbox: {
         base: 'ChromeHeadless',
         flags: ['--no-sandbox']
+      },
+      Chrome_with_debugging: {
+        base: 'Chrome',
+        flags: ['--remote-debugging-port=9222'],
+        debug: true
       }
     },
     singleRun: false,

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,10 @@ export function configure() {
     if (!isAttached) {
       eachMethod(this.viewModel, value => {
         key(value.combo.shortcuts, e => {
+          if (!value.combo.runInsideInputs && !defaultKeymasterFilter(e)) {
+            return true;
+          }
+          
           const result = value.call(this.viewModel, e);
           // return true to skip preventDefault
           if (result !== true) {
@@ -44,6 +48,11 @@ export function configure() {
   };
 }
 
+function defaultKeymasterFilter(event) {
+  const tagName = (event.target || event.srcElement).tagName;
+  return !(tagName == 'INPUT' || tagName == 'SELECT' || tagName == 'TEXTAREA');
+}
+
 function eachMethod(obj, callback) {
   const names = Object.getOwnPropertyNames(obj);
   for (const name of names) {
@@ -60,7 +69,7 @@ function eachMethod(obj, callback) {
   }
 }
 
-export function combo(shortcuts) {
+export function combo(shortcuts, runInsideInputs) {
   if (!shortcuts || !shortcuts.length) return;
 
   return function(target, _key, descriptor) {
@@ -69,7 +78,8 @@ export function combo(shortcuts) {
     }
 
     descriptor.value.combo = {
-      shortcuts
+      shortcuts,
+      runInsideInputs
     };
 
     return descriptor;

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ export function configure() {
 
     if (!isAttached) {
       eachMethod(this.viewModel, value => {
-        key(value.combo, e => {
+        key(value.combo.shortcuts, e => {
           const result = value.call(this.viewModel, e);
           // return true to skip preventDefault
           if (result !== true) {
@@ -38,7 +38,7 @@ export function configure() {
 
     if (isAttached) {
       eachMethod(this.viewModel, value => {
-        key.unbind(value.combo);
+        key.unbind(value.combo.shortcuts);
       });
     }
   };
@@ -60,7 +60,7 @@ function eachMethod(obj, callback) {
   }
 }
 
-export function combo(...shortcuts) {
+export function combo(shortcuts) {
   if (!shortcuts || !shortcuts.length) return;
 
   return function(target, _key, descriptor) {
@@ -68,7 +68,10 @@ export function combo(...shortcuts) {
       throw new Error('@combo(...) can only decorate a method');
     }
 
-    descriptor.value.combo = shortcuts.join(', ');
+    descriptor.value.combo = {
+      shortcuts
+    };
+
     return descriptor;
   };
 }

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ export function configure() {
       eachMethod(this.viewModel, value => {
         key(value.combo.shortcuts, e => {
           if (!value.combo.runInsideInputs && !defaultKeymasterFilter(e)) {
-            return true;
+            return;
           }
 
           const result = value.call(this.viewModel, e);

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ export function configure() {
   const attached = Controller.prototype.attached;
   const detached = Controller.prototype.detached;
 
+  const defaultKeymasterFilter = key.filter;
   key.filter = () => true; // disable Keymaster's built-in filter
 
   Controller.prototype.attached = function() {
@@ -46,11 +47,6 @@ export function configure() {
       });
     }
   };
-}
-
-function defaultKeymasterFilter(event) {
-  const tagName = (event.target || event.srcElement).tagName;
-  return !(tagName === 'INPUT' || tagName === 'SELECT' || tagName === 'TEXTAREA');
 }
 
 function eachMethod(obj, callback) {

--- a/src/index.js
+++ b/src/index.js
@@ -69,8 +69,13 @@ function eachMethod(obj, callback) {
   }
 }
 
-export function combo(shortcuts, runInsideInputs) {
+export function combo(...shortcuts) {
   if (!shortcuts || !shortcuts.length) return;
+
+  let runInsideInputs = false;
+  if (shortcuts.length && typeof shortcuts[shortcuts.length - 1] === 'boolean') {
+    runInsideInputs = shortcuts.pop();
+  }
 
   return function(target, _key, descriptor) {
     if (typeof descriptor.value !== 'function') {
@@ -78,7 +83,7 @@ export function combo(shortcuts, runInsideInputs) {
     }
 
     descriptor.value.combo = {
-      shortcuts,
+      shortcuts: shortcuts.join(','),
       runInsideInputs
     };
 

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ export function configure() {
           if (!value.combo.runInsideInputs && !defaultKeymasterFilter(e)) {
             return true;
           }
-          
+
           const result = value.call(this.viewModel, e);
           // return true to skip preventDefault
           if (result !== true) {
@@ -50,7 +50,7 @@ export function configure() {
 
 function defaultKeymasterFilter(event) {
   const tagName = (event.target || event.srcElement).tagName;
-  return !(tagName == 'INPUT' || tagName == 'SELECT' || tagName == 'TEXTAREA');
+  return !(tagName === 'INPUT' || tagName === 'SELECT' || tagName === 'TEXTAREA');
 }
 
 function eachMethod(obj, callback) {

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,8 @@ export function configure() {
   const attached = Controller.prototype.attached;
   const detached = Controller.prototype.detached;
 
+  key.filter = () => true; // disable Keymaster's built-in filter
+
   Controller.prototype.attached = function() {
     // attached() gets called twice but only does things when isAttached is false
     let isAttached = this.isAttached;

--- a/test/unit/combo.spec.js
+++ b/test/unit/combo.spec.js
@@ -43,7 +43,7 @@ const results = [];
 
 @inlineView('<template></template>')
 class ToTest {
-  @combo('ctrl+f', 'command+f')
+  @combo('ctrl+f, command+f')
   findIt() {
     results.push('findIt');
   }

--- a/test/unit/combo.spec.js
+++ b/test/unit/combo.spec.js
@@ -43,7 +43,7 @@ const results = [];
 
 @inlineView('<template></template>')
 class ToTest {
-  @combo('ctrl+f, command+f')
+  @combo('ctrl+f', 'command+f')
   findIt() {
     results.push('findIt');
   }

--- a/test/unit/combo.spec.js
+++ b/test/unit/combo.spec.js
@@ -34,7 +34,7 @@ function keyup(code) {
   var event = document.createEvent('Event');
   event.initEvent('keyup', true, true);
   event.keyCode = code;
-  document.dispatchEvent(event);
+  document.activeElement.dispatchEvent(event);
 }
 
 const nq = createAssertionQueue();


### PR DESCRIPTION
* Disable the default filter that Keymaster uses, processing key commands on all keypresses.
* Changing the signature of `@combo()` to declare a list of shortcuts as a single parameter.
* Adding a second parameter, `runInsideInputs`, a flag to determine whether we should filter or not.
* Adding an `if` block inside the Keymaster handler to `return true` if we should be filtering inside inputs, and the default filter detects that we are currently in an input.

I added examples of both to the `dev-app`.