### PR TITLE
Add booleans to the TypeScript definition for `@combo()`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,2 +1,2 @@
-export declare function combo(...shortcuts: string[]): any;
+export declare function combo(...shortcuts: (string|boolean)[]): any;
 export declare function configure(frameworkConfig?: any): void;


### PR DESCRIPTION
In index.d.ts, the combo() function defines shortcuts as string[]. Now that we've made implemented #1 , We'll need to update the TypeScript definition to allow strings or booleans.